### PR TITLE
Bugfix: remove unintended char and correct symbol file path

### DIFF
--- a/QuickPay/Quickpay.nuspec
+++ b/QuickPay/Quickpay.nuspec
@@ -21,6 +21,6 @@
   </metadata>
    <files>
 	  <file src="./bin/Debug/QuickPay.dll" target="lib" />
-	  <file src="./bin/Debug/QuickPay.dll.mdb" target="lib" />
-  </files>k
+	  <file src="./bin/Debug/QuickPay.pdb" target="lib" />
+  </files>
 </package>


### PR DESCRIPTION
Errors in the nuspec file prevent the nupkg from building correctly, and hence installing from nuget fails quietly, leaving no reference to the Quickpay.dll
